### PR TITLE
implemented draw-methods around nk-basecalls

### DIFF
--- a/Src/Visual Studio/Nuk/AuswertungNuk/NukForm.h
+++ b/Src/Visual Studio/Nuk/AuswertungNuk/NukForm.h
@@ -3,6 +3,7 @@
 #define NUK_FORM_H
 
 #include <nuk_controls.h>
+#include "../../Independed/Process.h"
 
 #endif
 

--- a/Src/Visual Studio/Nuk/AuswertungNuk/main.cpp
+++ b/Src/Visual Studio/Nuk/AuswertungNuk/main.cpp
@@ -65,6 +65,10 @@ int main(int argc, char** argv)
 	edit2->cursorpos = edit2->text.length();
 	mainForm.fields.push_back(edit2.get());
 
+	std::unique_ptr<nk::TStatusBar> statusBar = std::make_unique<nk::TStatusBar>(viewport.Width, viewport.Height, "testStatus", ++id);
+	statusBar->text = "statustext";
+	mainForm.fields.push_back(statusBar.get());
+
 	app.Run(mainForm);
 	app.Release();
 	return 0;

--- a/Src/Visual Studio/Nuk/AuswertungNuk/main.cpp
+++ b/Src/Visual Studio/Nuk/AuswertungNuk/main.cpp
@@ -42,11 +42,13 @@ int main(int argc, char** argv)
 #endif
 {
 	Application app;
+
 	TProcess proc;
 	app.Init(WINDOW_WIDTH, WINDOW_HEIGHT);
 
 	const D3D11_VIEWPORT& viewport = app.GetViewport();
 	__int64 id = 0;
+	
 	nk::NKForm mainForm(viewport.Width, viewport.Height, "Demo", id);
 
 	auto dualRow = [](struct nk_context* ctx)
@@ -54,26 +56,23 @@ int main(int argc, char** argv)
 		nk_layout_row_dynamic(ctx, 30, 2);
 	};
 
-	std::unique_ptr<nk::TEdit> edit = std::make_unique<nk::TEdit>( "path", ++id );
+	nk::TEdit* edit = mainForm.Create<nk::TEdit>("path", ++id);
 	edit->applyLayout = dualRow;
 	edit->text = "hello"; 
 	edit->cursorpos = edit->text.length();
-	mainForm.fields.push_back(edit.get());
-
-	std::unique_ptr<nk::TEdit> edit2 = std::make_unique<nk::TEdit>("second", ++id);
+	
+	nk::TEdit* edit2 = mainForm.Create<nk::TEdit>("second", ++id);
 	edit2->text = "hello2";
 	//edit2->applyLayout = singleRow;
 	edit2->cursorpos = edit2->text.length();
-	mainForm.fields.push_back(edit2.get());
-
-	std::unique_ptr<nk::TStatusBar> statusBar = std::make_unique<nk::TStatusBar>(viewport.Width, viewport.Height, "testStatus", ++id);
+	
+	nk::TStatusBar* statusBar = mainForm.Create<nk::TStatusBar>(viewport.Width, viewport.Height, "testStatus", ++id);
 	statusBar->text = "statustext";
-	mainForm.fields.push_back(statusBar.get());
-
+	
 	//Form-Created
 	try
 	{
-		proc.Init({ &mainForm,false });
+		//proc.Init({ &mainForm,false });
 
 		app.Run(mainForm);
 	}
@@ -81,6 +80,7 @@ int main(int argc, char** argv)
 	{
 		std::cerr << re.what() << "\n";
 	}
+	
 	app.Release();
 	return 0;
 }

--- a/Src/Visual Studio/Nuk/AuswertungNuk/main.cpp
+++ b/Src/Visual Studio/Nuk/AuswertungNuk/main.cpp
@@ -52,7 +52,7 @@ int main(int argc, char** argv)
 
 	auto dualRow = [](struct nk_context* ctx)
 	{
-		nk_layout_row_dynamic(ctx, 30, 2);
+		nk_layout_row_dynamic(ctx, 25, 10);
 	};
 
 	nk::TEdit* edit = mainForm.Create<nk::TEdit>("path");
@@ -65,6 +65,12 @@ int main(int argc, char** argv)
 	//edit2->applyLayout = singleRow;
 	edit2->cursorpos = edit2->text.length();
 	
+	for (int tst = 0; tst < 10000; ++tst)
+	{
+		nk::TLabel* lbl=mainForm.Create<nk::TLabel>("","--");
+		mainForm.Create<nk::TEdit>("");
+	}
+
 	nk::TStatusBar* statusBar = mainForm.Create<nk::TStatusBar>(viewport.Width, viewport.Height, "testStatus");
 	statusBar->text = "statustext";
 	

--- a/Src/Visual Studio/Nuk/AuswertungNuk/main.cpp
+++ b/Src/Visual Studio/Nuk/AuswertungNuk/main.cpp
@@ -44,9 +44,26 @@ int main(int argc, char** argv)
 	Application app;
 	app.Init(WINDOW_WIDTH, WINDOW_HEIGHT);
 
-	const D3D11_VIEWPORT& viewport= app.GetViewport();
+	const D3D11_VIEWPORT& viewport = app.GetViewport();
+	__int64 id = 0;
+	nk::NKForm mainForm(viewport.Width, viewport.Height, "Demo", id);
 
-	nk::NKForm mainForm( viewport.Width, viewport.Height, "Demo", 1);
+	auto dualRow = [](nk_context* ctx)
+	{
+		nk_layout_row_dynamic(ctx, 30, 2);
+	};
+
+	std::unique_ptr<nk::TEdit> edit = std::make_unique<nk::TEdit>( "path", ++id );
+	edit->applyLayout = dualRow;
+	edit->text = "hello"; 
+	edit->cursorpos = edit->text.length();
+	mainForm.fields.push_back(edit.get());
+
+	std::unique_ptr<nk::TEdit> edit2 = std::make_unique<nk::TEdit>("second", ++id);
+	edit2->text = "hello2";
+	//edit2->applyLayout = singleRow;
+	edit2->cursorpos = edit2->text.length();
+	mainForm.fields.push_back(edit2.get());
 
 	app.Run(mainForm);
 	app.Release();

--- a/Src/Visual Studio/Nuk/AuswertungNuk/main.cpp
+++ b/Src/Visual Studio/Nuk/AuswertungNuk/main.cpp
@@ -47,26 +47,25 @@ int main(int argc, char** argv)
 	app.Init(WINDOW_WIDTH, WINDOW_HEIGHT);
 
 	const D3D11_VIEWPORT& viewport = app.GetViewport();
-	__int64 id = 0;
 	
-	nk::NKForm mainForm(viewport.Width, viewport.Height, "Demo", id);
+	nk::NKForm mainForm(viewport.Width, viewport.Height, "Demo", 0);
 
 	auto dualRow = [](struct nk_context* ctx)
 	{
 		nk_layout_row_dynamic(ctx, 30, 2);
 	};
 
-	nk::TEdit* edit = mainForm.Create<nk::TEdit>("path", ++id);
+	nk::TEdit* edit = mainForm.Create<nk::TEdit>("path");
 	edit->applyLayout = dualRow;
 	edit->text = "hello"; 
 	edit->cursorpos = edit->text.length();
 	
-	nk::TEdit* edit2 = mainForm.Create<nk::TEdit>("second", ++id);
+	nk::TEdit* edit2 = mainForm.Create<nk::TEdit>("second");
 	edit2->text = "hello2";
 	//edit2->applyLayout = singleRow;
 	edit2->cursorpos = edit2->text.length();
 	
-	nk::TStatusBar* statusBar = mainForm.Create<nk::TStatusBar>(viewport.Width, viewport.Height, "testStatus", ++id);
+	nk::TStatusBar* statusBar = mainForm.Create<nk::TStatusBar>(viewport.Width, viewport.Height, "testStatus");
 	statusBar->text = "statustext";
 	
 	//Form-Created

--- a/Src/Visual Studio/Nuk/AuswertungNuk/main.cpp
+++ b/Src/Visual Studio/Nuk/AuswertungNuk/main.cpp
@@ -52,7 +52,7 @@ int main(int argc, char** argv)
 
 	auto dualRow = [](struct nk_context* ctx)
 	{
-		nk_layout_row_dynamic(ctx, 25, 10);
+		nk_layout_row_dynamic(ctx, 25, 20);
 	};
 
 	nk::TEdit* edit = mainForm.Create<nk::TEdit>("path");
@@ -64,10 +64,13 @@ int main(int argc, char** argv)
 	edit2->text = "hello2";
 	//edit2->applyLayout = singleRow;
 	edit2->cursorpos = edit2->text.length();
-	
-	for (int tst = 0; tst < 10000; ++tst)
+#ifndef NDEBUG
+	for (int tst = 0; tst < 1000; ++tst)
+#else
+	for (int tst = 0; tst < 200000; ++tst)
+#endif
 	{
-		nk::TLabel* lbl=mainForm.Create<nk::TLabel>("","--");
+		nk::TLabel* lbl=mainForm.Create<nk::TLabel>("",std::to_string(tst) );
 		mainForm.Create<nk::TEdit>("");
 	}
 

--- a/Src/Visual Studio/Nuk/AuswertungNuk/main.cpp
+++ b/Src/Visual Studio/Nuk/AuswertungNuk/main.cpp
@@ -42,13 +42,14 @@ int main(int argc, char** argv)
 #endif
 {
 	Application app;
+	TProcess proc;
 	app.Init(WINDOW_WIDTH, WINDOW_HEIGHT);
 
 	const D3D11_VIEWPORT& viewport = app.GetViewport();
 	__int64 id = 0;
 	nk::NKForm mainForm(viewport.Width, viewport.Height, "Demo", id);
 
-	auto dualRow = [](nk_context* ctx)
+	auto dualRow = [](struct nk_context* ctx)
 	{
 		nk_layout_row_dynamic(ctx, 30, 2);
 	};
@@ -69,7 +70,17 @@ int main(int argc, char** argv)
 	statusBar->text = "statustext";
 	mainForm.fields.push_back(statusBar.get());
 
-	app.Run(mainForm);
+	//Form-Created
+	try
+	{
+		proc.Init({ &mainForm,false });
+
+		app.Run(mainForm);
+	}
+	catch (std::runtime_error re)
+	{
+		std::cerr << re.what() << "\n";
+	}
 	app.Release();
 	return 0;
 }

--- a/Src/Visual Studio/Nuk/AuswertungNuk/main.cpp
+++ b/Src/Visual Studio/Nuk/AuswertungNuk/main.cpp
@@ -55,12 +55,12 @@ int main(int argc, char** argv)
 		nk_layout_row_dynamic(ctx, 25, 20);
 	};
 
-	nk::TEdit* edit = mainForm.Create<nk::TEdit>("path");
+	nk::TEdit* edit = mainForm.AddField<nk::TEdit>("path");
 	edit->applyLayout = dualRow;
 	edit->text = "hello"; 
 	edit->cursorpos = edit->text.length();
 	
-	nk::TEdit* edit2 = mainForm.Create<nk::TEdit>("second");
+	nk::TEdit* edit2 = mainForm.AddField<nk::TEdit>("second");
 	edit2->text = "hello2";
 	//edit2->applyLayout = singleRow;
 	edit2->cursorpos = edit2->text.length();
@@ -70,11 +70,11 @@ int main(int argc, char** argv)
 	for (int tst = 0; tst < 200000; ++tst)
 #endif
 	{
-		nk::TLabel* lbl=mainForm.Create<nk::TLabel>("",std::to_string(tst) );
-		mainForm.Create<nk::TEdit>("");
+		nk::TLabel* lbl=mainForm.AddField<nk::TLabel>("",std::to_string(tst) );
+		mainForm.AddField<nk::TEdit>("");
 	}
 
-	nk::TStatusBar* statusBar = mainForm.Create<nk::TStatusBar>(viewport.Width, viewport.Height, "testStatus");
+	nk::TStatusBar* statusBar = mainForm.AddField<nk::TStatusBar>(viewport.Width, viewport.Height, "testStatus");
 	statusBar->text = "statustext";
 	
 	//Form-Created

--- a/Src/Visual Studio/Nuk/AuswertungNuk/nuk_header_only/nuk_controls.cpp
+++ b/Src/Visual Studio/Nuk/AuswertungNuk/nuk_header_only/nuk_controls.cpp
@@ -3,7 +3,8 @@
 
 nk::TStatusBar::TStatusBar(
 	const float& w, const float& h, 
-	std::string Name, __int64 _id
+	std::string Name,
+	__int64 _id
 	) :
 	IComponent(Name, _id),
 	window_height(h),

--- a/Src/Visual Studio/Nuk/AuswertungNuk/nuk_header_only/nuk_controls.cpp
+++ b/Src/Visual Studio/Nuk/AuswertungNuk/nuk_header_only/nuk_controls.cpp
@@ -27,8 +27,8 @@ nk::IComponent* nk::IComponent::FindComponent(std::string const & strField)
 }
 
 
-nk::TStatusBar::TStatusBar(	const float& w, const float& h,
-	std::string Name, __int64 _id ) noexcept
+nk::TStatusBar::TStatusBar(const float& w, const float& h,
+	std::string Name, __int64 _id) noexcept
 	:
 	IComponent(Name, _id),
 	window_height(h),
@@ -39,14 +39,14 @@ nk::TStatusBar::TStatusBar(	const float& w, const float& h,
 void nk::TStatusBar::draw(struct nk_context* ctx)
 {
 	if (nk_begin(ctx, name.c_str(),
-		nk_rect(2.0f, window_height-status_height, window_width-2.0f, status_height),
+		nk_rect(2.0f, window_height - status_height, window_width - 2.0f, status_height),
 		NK_WINDOW_BORDER | NK_WINDOW_NO_SCROLLBAR))
 	{
-			nk_layout_row_dynamic(ctx, status_height, 1);
-			nk_label(ctx, "statustext", NK_TEXT_CENTERED);
+		nk_layout_row_dynamic(ctx, status_height, 1);
+		nk_label(ctx, "statustext", NK_TEXT_CENTERED);
 	}
 	nk_end(ctx);
-	
+
 }
 
 nk::TGroupBox::TGroupBox(std::string Name, __int64 _id) noexcept
@@ -69,7 +69,7 @@ void nk::TGroupBox::draw(struct nk_context* ctx)
 
 
 
-nk::NKForm::NKForm(	const float & width, const float & height,
+nk::NKForm::NKForm(const float & width, const float & height,
 	std::string Name, __int64 _id) noexcept
 	:
 	IComponent(Name, _id),
@@ -93,7 +93,7 @@ void nk::NKForm::draw(struct nk_context* ctx)
 		for (nk::IComponent* comp : fields)
 		{
 			if (comp->ComponentType() != EMyFrameworkType::statusbar
-				&& comp->ComponentType()!=EMyFrameworkType::form
+				&& comp->ComponentType() != EMyFrameworkType::form
 				)
 			{
 				if (comp->applyLayout)
@@ -120,12 +120,12 @@ nk::TEdit::TEdit(std::string Name, __int64 _id) noexcept
 	:
 	IComponent(Name, _id)
 {
-	
+
 }
 
 void nk::TEdit::draw(struct nk_context* ctx)
 {
-	if (text.capacity() < (text.size() + 10) )
+	if (text.capacity() < (text.size() + 10))
 	{
 		text.resize(text.capacity() + 64);
 	}

--- a/Src/Visual Studio/Nuk/AuswertungNuk/nuk_header_only/nuk_controls.cpp
+++ b/Src/Visual Studio/Nuk/AuswertungNuk/nuk_header_only/nuk_controls.cpp
@@ -1,32 +1,34 @@
 #include <nuklear.h>
 #include "nuk_controls.h"
 
-nk::TStatusBar::TStatusBar(int & h, int & w, std::string Name, __int64 _id) :
+nk::TStatusBar::TStatusBar(
+	const float& w, const float& h, 
+	std::string Name, __int64 _id
+	) :
 	IComponent(Name, _id),
 	window_height(h),
 	window_width(w),
 	status_height(30)
 {}
 
-void nk::TStatusBar::draw(nk_context * ctx)
+void nk::TStatusBar::draw(struct nk_context* ctx)
 {
 	if (nk_begin(ctx, name.c_str(),
-		nk_rect(0.0f, (float)(window_height - status_height),
-		(float)window_width, (float)status_height),
-		NK_WINDOW_BORDER | NK_WINDOW_NO_SCROLLBAR
-	))
+		nk_rect(2.0f, window_height-status_height, window_width-2.0f, status_height),
+		NK_WINDOW_BORDER | NK_WINDOW_NO_SCROLLBAR))
 	{
-		nk_layout_row_dynamic(ctx, ctx->current->bounds.h, 1);
-		nk_label(ctx, text.c_str(), NK_TEXT_CENTERED);
+			nk_layout_row_dynamic(ctx, status_height, 1);
+			nk_label(ctx, "statustext", NK_TEXT_LEFT);
 	}
 	nk_end(ctx);
+	
 }
 
 nk::TGroupBox::TGroupBox(std::string Name, __int64 _id) :
 	IComponent(Name, _id)
 {}
 
-void nk::TGroupBox::draw(nk_context * ctx)
+void nk::TGroupBox::draw(struct nk_context* ctx)
 {
 	nk_group_begin_titled(ctx, name.c_str(), title.c_str(), nk_panel_flags::NK_WINDOW_BORDER);
 	nk_layout_row_begin(ctx, nk_layout_format::NK_STATIC, 20, 1);
@@ -78,7 +80,7 @@ EMyFrameworkType nk::NKForm::ComponentType() const
 	return EMyFrameworkType::form;
 }
 
-void nk::NKForm::draw(nk_context * ctx)
+void nk::NKForm::draw(struct nk_context* ctx)
 {
 	float width = Width * 0.8f;
 	if (nk_begin(ctx, name.c_str(), nk_rect(0, 0, width, Height*0.8f),
@@ -90,7 +92,9 @@ void nk::NKForm::draw(nk_context * ctx)
 		
 		for (nk::IComponent* comp : fields)
 		{
-			if (comp->ComponentType() != EMyFrameworkType::statusbar)
+			if (comp->ComponentType() != EMyFrameworkType::statusbar
+				&& comp->ComponentType()!=EMyFrameworkType::form
+				)
 			{
 				if (comp->applyLayout)
 				{
@@ -99,13 +103,17 @@ void nk::NKForm::draw(nk_context * ctx)
 				comp->draw(ctx);
 			}
 		}
-		for (nk::IComponent* comp : fields)
-		{
-			if (comp->ComponentType() == EMyFrameworkType::statusbar)
-				comp->draw(ctx);
-		}
 	}
 	nk_end(ctx);
+
+	//other forms, and the statusbar -> after nk_end
+	for (nk::IComponent* comp : fields)
+	{
+		if (comp->ComponentType() == EMyFrameworkType::statusbar
+			|| comp->ComponentType() == EMyFrameworkType::form
+			)
+			comp->draw(ctx);
+	}
 }
 
 nk::TEdit::TEdit(std::string Name, __int64 _id) :
@@ -114,7 +122,7 @@ nk::TEdit::TEdit(std::string Name, __int64 _id) :
 	
 }
 
-void nk::TEdit::draw(nk_context * ctx)
+void nk::TEdit::draw(struct nk_context* ctx)
 {
 	if (text.capacity() < (text.size() + 10) )
 	{
@@ -127,7 +135,7 @@ nk::TLabel::TLabel(std::string Name, __int64 _id) :
 	IComponent(Name, _id)
 {}
 
-void nk::TLabel::draw(nk_context * ctx)
+void nk::TLabel::draw(struct nk_context* ctx)
 {
 }
 
@@ -135,7 +143,7 @@ nk::TButton::TButton(std::string Name, __int64 _id) :
 	IComponent(Name, _id)
 {}
 
-void nk::TButton::draw(nk_context * ctx)
+void nk::TButton::draw(struct nk_context* ctx)
 {
 }
 
@@ -143,7 +151,7 @@ nk::TListbox::TListbox(std::string Name, __int64 _id) :
 	IComponent(Name, _id)
 {}
 
-void nk::TListbox::draw(nk_context * ctx)
+void nk::TListbox::draw(struct nk_context* ctx)
 {
 }
 
@@ -151,7 +159,7 @@ nk::TCheckbox::TCheckbox(std::string Name, __int64 _id) :
 	IComponent(Name, _id)
 {}
 
-void nk::TCheckbox::draw(nk_context * ctx)
+void nk::TCheckbox::draw(struct nk_context* ctx)
 {
 }
 
@@ -159,7 +167,7 @@ nk::TCombobox::TCombobox(std::string Name, __int64 _id) :
 	IComponent(Name, _id)
 {}
 
-void nk::TCombobox::draw(nk_context * ctx)
+void nk::TCombobox::draw(struct nk_context* ctx)
 {
 }
 
@@ -167,7 +175,7 @@ nk::TMemo::TMemo(std::string Name, __int64 _id) :
 	IComponent(Name, _id)
 {}
 
-void nk::TMemo::draw(nk_context * ctx)
+void nk::TMemo::draw(struct nk_context* ctx)
 {
 }
 
@@ -175,6 +183,6 @@ nk::TGrid::TGrid(std::string Name, __int64 _id) :
 	IComponent(Name, _id)
 {}
 
-void nk::TGrid::draw(nk_context * ctx)
+void nk::TGrid::draw(struct nk_context* ctx)
 {
 }

--- a/Src/Visual Studio/Nuk/AuswertungNuk/nuk_header_only/nuk_controls.cpp
+++ b/Src/Visual Studio/Nuk/AuswertungNuk/nuk_header_only/nuk_controls.cpp
@@ -80,15 +80,29 @@ EMyFrameworkType nk::NKForm::ComponentType() const
 
 void nk::NKForm::draw(nk_context * ctx)
 {
-	if (nk_begin(ctx, name.c_str(), nk_rect(0, 0, Width, Height),
+	float width = Width * 0.8f;
+	if (nk_begin(ctx, name.c_str(), nk_rect(0, 0, width, Height*0.8f),
 		NK_WINDOW_BORDER | NK_WINDOW_TITLE
 		//| NK_WINDOW_SCALABLE | NK_WINDOW_MOVABLE //<- updates bounds.. fullscreenwindow
 		| NK_WINDOW_MINIMIZABLE
 	))
 	{
+		
 		for (nk::IComponent* comp : fields)
 		{
-			comp->draw(ctx);
+			if (comp->ComponentType() != EMyFrameworkType::statusbar)
+			{
+				if (comp->applyLayout)
+				{
+					comp->applyLayout(ctx);
+				}
+				comp->draw(ctx);
+			}
+		}
+		for (nk::IComponent* comp : fields)
+		{
+			if (comp->ComponentType() == EMyFrameworkType::statusbar)
+				comp->draw(ctx);
 		}
 	}
 	nk_end(ctx);
@@ -96,10 +110,17 @@ void nk::NKForm::draw(nk_context * ctx)
 
 nk::TEdit::TEdit(std::string Name, __int64 _id) :
 	IComponent(Name, _id)
-{}
+{
+	
+}
 
 void nk::TEdit::draw(nk_context * ctx)
 {
+	if (text.capacity() < (text.size() + 10) )
+	{
+		text.resize(text.capacity() + 64);
+	}
+	nk_edit_string(ctx, NK_EDIT_SIMPLE, text.data(), &cursorpos, text.capacity(), nk_filter_default);
 }
 
 nk::TLabel::TLabel(std::string Name, __int64 _id) :

--- a/Src/Visual Studio/Nuk/AuswertungNuk/nuk_header_only/nuk_controls.cpp
+++ b/Src/Visual Studio/Nuk/AuswertungNuk/nuk_header_only/nuk_controls.cpp
@@ -1,6 +1,32 @@
 #include <nuklear.h>
 #include "nuk_controls.h"
 
+nk::Pool nk::IComponent::componentPool; //static
+
+nk::IComponent::IComponent(std::string Name, __int64 _id)
+	: name(Name), id(_id)
+{
+	if (!name.length())
+	{
+		name = std::to_string(id);
+	}
+}
+
+nk::IComponent* nk::IComponent::FindComponent(std::string const & strField)
+{
+	for (nk::IComponent* c : fields)
+	{
+		if (!c) { continue; }
+		nk::IComponent* subChild = c->FindComponent(strField);
+		if (subChild) { return subChild; }
+
+		if (c->name != strField) { continue; }
+		return c;
+	}
+	return nullptr;
+}
+
+
 nk::TStatusBar::TStatusBar(
 	const float& w, const float& h, 
 	std::string Name,
@@ -41,30 +67,8 @@ void nk::TGroupBox::draw(struct nk_context* ctx)
 	nk_group_end(ctx);
 }
 
-nk::IComponent::IComponent(std::string Name, __int64 _id)
-	: name(Name), id(_id)
-{
-	if (!name.length())
-	{
-		name = std::to_string(id);
-	}
-}
 
-nk::IComponent * nk::IComponent::FindComponent(std::string const & strField)
-{
-	for (nk::IComponent* c : fields)
-	{
-		if (!c) { continue; }
-		nk::IComponent* subChild = c->FindComponent(strField);
-		if (subChild) { return subChild; }
-		
-		if (c->name != strField) { continue; }
-		return c;
-	}
-	return nullptr;
-}
 
-nk::Pool nk::NKForm::componentPool; //static
 
 nk::NKForm::NKForm(
 	const float & width,

--- a/Src/Visual Studio/Nuk/AuswertungNuk/nuk_header_only/nuk_controls.cpp
+++ b/Src/Visual Studio/Nuk/AuswertungNuk/nuk_header_only/nuk_controls.cpp
@@ -54,9 +54,10 @@ nk::IComponent * nk::IComponent::FindComponent(std::string const & strField)
 	for (nk::IComponent* c : fields)
 	{
 		if (!c) { continue; }
-		if (c->name != strField) { continue; }
 		nk::IComponent* subChild = c->FindComponent(strField);
 		if (subChild) { return subChild; }
+		
+		if (c->name != strField) { continue; }
 		return c;
 	}
 	return nullptr;
@@ -89,7 +90,6 @@ void nk::NKForm::draw(struct nk_context* ctx)
 		| NK_WINDOW_MINIMIZABLE
 	))
 	{
-		
 		for (nk::IComponent* comp : fields)
 		{
 			if (comp->ComponentType() != EMyFrameworkType::statusbar

--- a/Src/Visual Studio/Nuk/AuswertungNuk/nuk_header_only/nuk_controls.cpp
+++ b/Src/Visual Studio/Nuk/AuswertungNuk/nuk_header_only/nuk_controls.cpp
@@ -3,7 +3,7 @@
 
 nk::Pool nk::IComponent::componentPool; //static
 
-nk::IComponent::IComponent(std::string Name, __int64 _id)
+nk::IComponent::IComponent(std::string Name, __int64 _id) noexcept
 	: name(Name), id(_id)
 {
 	if (!name.length())
@@ -27,11 +27,9 @@ nk::IComponent* nk::IComponent::FindComponent(std::string const & strField)
 }
 
 
-nk::TStatusBar::TStatusBar(
-	const float& w, const float& h, 
-	std::string Name,
-	__int64 _id
-	) :
+nk::TStatusBar::TStatusBar(	const float& w, const float& h,
+	std::string Name, __int64 _id ) noexcept
+	:
 	IComponent(Name, _id),
 	window_height(h),
 	window_width(w),
@@ -51,7 +49,8 @@ void nk::TStatusBar::draw(struct nk_context* ctx)
 	
 }
 
-nk::TGroupBox::TGroupBox(std::string Name, __int64 _id) :
+nk::TGroupBox::TGroupBox(std::string Name, __int64 _id) noexcept
+	:
 	IComponent(Name, _id)
 {}
 
@@ -70,11 +69,8 @@ void nk::TGroupBox::draw(struct nk_context* ctx)
 
 
 
-nk::NKForm::NKForm(
-	const float & width,
-	const float & height, 
-	std::string Name, 
-	__int64 _id)
+nk::NKForm::NKForm(	const float & width, const float & height,
+	std::string Name, __int64 _id) noexcept
 	:
 	IComponent(Name, _id),
 	Width(width),
@@ -120,7 +116,8 @@ void nk::NKForm::draw(struct nk_context* ctx)
 	}
 }
 
-nk::TEdit::TEdit(std::string Name, __int64 _id) :
+nk::TEdit::TEdit(std::string Name, __int64 _id) noexcept
+	:
 	IComponent(Name, _id)
 {
 	
@@ -135,7 +132,8 @@ void nk::TEdit::draw(struct nk_context* ctx)
 	nk_edit_string(ctx, NK_EDIT_SIMPLE, text.data(), &cursorpos, text.capacity(), nk_filter_default);
 }
 
-nk::TLabel::TLabel(std::string Name, std::string Text, __int64 _id) :
+nk::TLabel::TLabel(std::string Name, std::string Text, __int64 _id) noexcept
+	:
 	IComponent(Name, _id),
 	text(Text)
 {
@@ -146,7 +144,8 @@ void nk::TLabel::draw(struct nk_context* ctx)
 	nk_label(ctx, text.c_str(), NK_TEXT_ALIGN_LEFT);
 }
 
-nk::TButton::TButton(std::string Name, __int64 _id) :
+nk::TButton::TButton(std::string Name, __int64 _id) noexcept
+	:
 	IComponent(Name, _id)
 {}
 
@@ -154,7 +153,8 @@ void nk::TButton::draw(struct nk_context* ctx)
 {
 }
 
-nk::TListbox::TListbox(std::string Name, __int64 _id) :
+nk::TListbox::TListbox(std::string Name, __int64 _id) noexcept
+	:
 	IComponent(Name, _id)
 {}
 
@@ -162,7 +162,8 @@ void nk::TListbox::draw(struct nk_context* ctx)
 {
 }
 
-nk::TCheckbox::TCheckbox(std::string Name, __int64 _id) :
+nk::TCheckbox::TCheckbox(std::string Name, __int64 _id) noexcept
+	:
 	IComponent(Name, _id)
 {}
 
@@ -170,7 +171,8 @@ void nk::TCheckbox::draw(struct nk_context* ctx)
 {
 }
 
-nk::TCombobox::TCombobox(std::string Name, __int64 _id) :
+nk::TCombobox::TCombobox(std::string Name, __int64 _id) noexcept
+	:
 	IComponent(Name, _id)
 {}
 
@@ -178,7 +180,8 @@ void nk::TCombobox::draw(struct nk_context* ctx)
 {
 }
 
-nk::TMemo::TMemo(std::string Name, __int64 _id) :
+nk::TMemo::TMemo(std::string Name, __int64 _id) noexcept
+	:
 	IComponent(Name, _id)
 {}
 
@@ -186,7 +189,8 @@ void nk::TMemo::draw(struct nk_context* ctx)
 {
 }
 
-nk::TGrid::TGrid(std::string Name, __int64 _id) :
+nk::TGrid::TGrid(std::string Name, __int64 _id) noexcept
+	:
 	IComponent(Name, _id)
 {}
 

--- a/Src/Visual Studio/Nuk/AuswertungNuk/nuk_header_only/nuk_controls.cpp
+++ b/Src/Visual Studio/Nuk/AuswertungNuk/nuk_header_only/nuk_controls.cpp
@@ -18,7 +18,7 @@ void nk::TStatusBar::draw(struct nk_context* ctx)
 		NK_WINDOW_BORDER | NK_WINDOW_NO_SCROLLBAR))
 	{
 			nk_layout_row_dynamic(ctx, status_height, 1);
-			nk_label(ctx, "statustext", NK_TEXT_LEFT);
+			nk_label(ctx, "statustext", NK_TEXT_CENTERED);
 	}
 	nk_end(ctx);
 	
@@ -63,7 +63,7 @@ nk::IComponent * nk::IComponent::FindComponent(std::string const & strField)
 	return nullptr;
 }
 
-
+nk::Pool nk::NKForm::componentPool; //static
 
 nk::NKForm::NKForm(
 	const float & width,
@@ -83,10 +83,9 @@ EMyFrameworkType nk::NKForm::ComponentType() const
 
 void nk::NKForm::draw(struct nk_context* ctx)
 {
-	float width = Width * 0.8f;
-	if (nk_begin(ctx, name.c_str(), nk_rect(0, 0, width, Height*0.8f),
+	if (nk_begin(ctx, name.c_str(), nk_rect(0.0f, 0.0f, Width*0.8f, Height*0.8f),
 		NK_WINDOW_BORDER | NK_WINDOW_TITLE
-		//| NK_WINDOW_SCALABLE | NK_WINDOW_MOVABLE //<- updates bounds.. fullscreenwindow
+		| NK_WINDOW_SCALABLE | NK_WINDOW_MOVABLE //<- updates bounds.. fullscreenwindow
 		| NK_WINDOW_MINIMIZABLE
 	))
 	{
@@ -186,3 +185,5 @@ nk::TGrid::TGrid(std::string Name, __int64 _id) :
 void nk::TGrid::draw(struct nk_context* ctx)
 {
 }
+
+

--- a/Src/Visual Studio/Nuk/AuswertungNuk/nuk_header_only/nuk_controls.cpp
+++ b/Src/Visual Studio/Nuk/AuswertungNuk/nuk_header_only/nuk_controls.cpp
@@ -131,12 +131,15 @@ void nk::TEdit::draw(struct nk_context* ctx)
 	nk_edit_string(ctx, NK_EDIT_SIMPLE, text.data(), &cursorpos, text.capacity(), nk_filter_default);
 }
 
-nk::TLabel::TLabel(std::string Name, __int64 _id) :
-	IComponent(Name, _id)
-{}
+nk::TLabel::TLabel(std::string Name, std::string Text, __int64 _id) :
+	IComponent(Name, _id),
+	text(Text)
+{
+}
 
 void nk::TLabel::draw(struct nk_context* ctx)
 {
+	nk_label(ctx, text.c_str(), NK_TEXT_ALIGN_LEFT);
 }
 
 nk::TButton::TButton(std::string Name, __int64 _id) :

--- a/Src/Visual Studio/Nuk/AuswertungNuk/nuk_header_only/nuk_controls.h
+++ b/Src/Visual Studio/Nuk/AuswertungNuk/nuk_header_only/nuk_controls.h
@@ -57,7 +57,7 @@ namespace nk
 		IComponent() = delete;
 		IComponent(const IComponent&) = delete;
 		
-		IComponent(std::string Name, __int64 _id);
+		IComponent(std::string Name, __int64 _id) noexcept;
 		virtual ~IComponent() = default;
 		virtual EMyFrameworkType ComponentType() const = 0;
 		
@@ -81,7 +81,7 @@ namespace nk
 
 	struct TEdit : public IComponent
 	{
-		TEdit(std::string Name, __int64 _id);
+		TEdit(std::string Name, __int64 _id) noexcept;
 		
 		std::string text;
 		int cursorpos = 0;
@@ -93,7 +93,7 @@ namespace nk
 	
 	struct TLabel : public IComponent
 	{
-		TLabel(std::string Name, std::string Text, __int64 _id);
+		TLabel(std::string Name, std::string Text, __int64 _id) noexcept;
 		std::string text;
 		virtual EMyFrameworkType ComponentType() const override {
 			return EMyFrameworkType::label;
@@ -103,7 +103,7 @@ namespace nk
 	
 	struct TGroupBox : public IComponent
 	{
-		TGroupBox(std::string Name, __int64 _id);
+		TGroupBox(std::string Name, __int64 _id) noexcept;
 		std::string title;
 		virtual EMyFrameworkType ComponentType() const override {
 			return EMyFrameworkType::groupbox;
@@ -113,7 +113,7 @@ namespace nk
 
 	struct TButton : public IComponent
 	{
-		TButton(std::string Name, __int64 _id);
+		TButton(std::string Name, __int64 _id) noexcept;
 		std::string text;
 		std::function<void()> onClick = nullptr;
 		virtual EMyFrameworkType ComponentType() const override {
@@ -124,7 +124,7 @@ namespace nk
 
 	struct TListbox : public IComponent
 	{
-		TListbox(std::string Name, __int64 _id);
+		TListbox(std::string Name, __int64 _id) noexcept;
 		std::vector<std::string> items;
 		int itemindex = -1;
 		size_t count() const { return items.size(); }
@@ -136,7 +136,7 @@ namespace nk
 
 	struct TCheckbox : public IComponent
 	{
-		TCheckbox(std::string Name, __int64 _id);
+		TCheckbox(std::string Name, __int64 _id) noexcept;
 		std::string text;
 		int checkstate = 0; //tristate?
 		virtual EMyFrameworkType ComponentType() const override {
@@ -147,7 +147,7 @@ namespace nk
 	
 	struct TCombobox : public IComponent
 	{
-		TCombobox(std::string Name, __int64 _id);
+		TCombobox(std::string Name, __int64 _id) noexcept;
 		std::string text;
 		std::vector<std::string> items;
 		int itemindex = -1;
@@ -160,7 +160,7 @@ namespace nk
 
 	struct TMemo : public IComponent
 	{
-		TMemo(std::string Name, __int64 _id);
+		TMemo(std::string Name, __int64 _id) noexcept;
 		std::vector<std::string> data;
 		//setText?
 
@@ -175,7 +175,7 @@ namespace nk
 		const float& window_height;
 		const float& window_width;
 
-		TStatusBar(const float& w, const float& h, std::string Name, __int64 _id);
+		TStatusBar(const float& w, const float& h, std::string Name, __int64 _id) noexcept;
 
 		std::string text;
 		float status_height;
@@ -188,7 +188,7 @@ namespace nk
 
 	struct TGrid : public IComponent
 	{
-		TGrid(std::string Name, __int64 _id);
+		TGrid(std::string Name, __int64 _id) noexcept;
 		struct THeadItem {
 			std::string caption;
 			int width = 10;
@@ -227,7 +227,7 @@ namespace nk
 		const float& Height;
 
 		NKForm( const float& width, const float& height, //width=d3d11.ViewPort.Width ->kind of global, should adapt on Resize!
-			std::string Name, __int64 _id);
+			std::string Name, __int64 _id) noexcept;
 
 		std::string title;
 		virtual EMyFrameworkType ComponentType() const override;

--- a/Src/Visual Studio/Nuk/AuswertungNuk/nuk_header_only/nuk_controls.h
+++ b/Src/Visual Studio/Nuk/AuswertungNuk/nuk_header_only/nuk_controls.h
@@ -187,13 +187,15 @@ namespace nk
 		virtual void draw(struct nk_context* ctx) override;
 	};
 
+
 	struct Pool
 	{
+		__int64 id = 100;
 		std::vector< std::unique_ptr<IComponent> > _owned;
 		template<typename outtype, class... Args>
 		outtype* Add(Args&&... ctor_args)
 		{
-			std::unique_ptr<outtype> comp = std::make_unique<outtype>(std::forward<Args>(ctor_args)...);
+			std::unique_ptr<outtype> comp = std::make_unique<outtype>(std::forward<Args>(ctor_args)..., ++id);
 			outtype* result = comp.get();
 			_owned.emplace_back(std::move(comp));
 			return result;

--- a/Src/Visual Studio/Nuk/AuswertungNuk/nuk_header_only/nuk_controls.h
+++ b/Src/Visual Studio/Nuk/AuswertungNuk/nuk_header_only/nuk_controls.h
@@ -44,7 +44,7 @@ namespace nk
 		//should redirect "events" -- in case of nuklear onClick is just a bool, discovered while painting
 		//should walk subcomponents, and draw them in specific order
 		virtual void draw(nk_context* ctx) = 0;
-
+		std::function<void(nk_context*)> applyLayout;
 		std::vector<IComponent*> fields;
 		IComponent* FindComponent(std::string const& strField);
 	};
@@ -53,6 +53,7 @@ namespace nk
 	{
 		TEdit(std::string Name, __int64 _id);
 		std::string text;
+		int cursorpos = 0;
 		virtual EMyFrameworkType ComponentType() const override{
 			return EMyFrameworkType::edit;
 		}

--- a/Src/Visual Studio/Nuk/AuswertungNuk/nuk_header_only/nuk_controls.h
+++ b/Src/Visual Studio/Nuk/AuswertungNuk/nuk_header_only/nuk_controls.h
@@ -33,17 +33,16 @@ namespace nk
 	{
 		__int64 id = 100;
 		std::vector< std::unique_ptr<IComponent> > _owned;
-		template<typename outtype, class... Args>
-		outtype* Add(Args&&... ctor_args)
+		template<typename fw_Type, class... Args>
+		fw_Type* Add(Args&&... ctor_args)
 		{
-			std::unique_ptr<outtype> comp
-				= std::make_unique<outtype>
-				(
+			std::unique_ptr<fw_Type> comp
+				= std::make_unique<fw_Type>(
 					std::forward<Args>(ctor_args)...,
 					++id
 					);
 
-			outtype* result = comp.get();
+			fw_Type* result = comp.get();
 			_owned.emplace_back(std::move(comp));
 			return result;
 		}
@@ -52,15 +51,16 @@ namespace nk
 	class IComponent
 	{
 	public:
-		std::string name;
-		__int64 id=0; //<- if name is empty we need a unique id
-		IComponent() = delete;
-		IComponent(const IComponent&) = delete;
-		
 		IComponent(std::string Name, __int64 _id) noexcept;
+		IComponent(const IComponent&) = delete;
+		IComponent() = delete;
+		
+		std::string name;
+		__int64 id = 0; //<- if name is empty we need a unique id
+
 		virtual ~IComponent() = default;
 		virtual EMyFrameworkType ComponentType() const = 0;
-		
+
 		//should draw the component
 		//should redirect "events" -- in case of nuklear onClick is just a bool, discovered while painting
 		//should walk subcomponents, and draw them in specific order
@@ -70,10 +70,12 @@ namespace nk
 		IComponent* FindComponent(std::string const& strField);
 
 		static Pool componentPool;
-		template<typename outtype, class... vaList_t>
-		outtype* AddField(vaList_t&&... i_values)
+		template<typename fw_Type, class... Args>
+		fw_Type* AddField(Args&&... ctor_args)
 		{
-			outtype* comp = componentPool.Add<outtype>(std::forward<vaList_t>(i_values)...);
+			fw_Type* comp = componentPool.Add<fw_Type>(
+				std::forward<Args>(ctor_args)...
+				);
 			this->fields.push_back(comp);
 			return comp;
 		}
@@ -82,15 +84,14 @@ namespace nk
 	struct TEdit : public IComponent
 	{
 		TEdit(std::string Name, __int64 _id) noexcept;
-		
 		std::string text;
 		int cursorpos = 0;
-		virtual EMyFrameworkType ComponentType() const override{
+		virtual EMyFrameworkType ComponentType() const override {
 			return EMyFrameworkType::edit;
 		}
 		virtual void draw(struct nk_context* ctx) override;
 	};
-	
+
 	struct TLabel : public IComponent
 	{
 		TLabel(std::string Name, std::string Text, __int64 _id) noexcept;
@@ -100,7 +101,7 @@ namespace nk
 		}
 		virtual void draw(struct nk_context* ctx) override;
 	};
-	
+
 	struct TGroupBox : public IComponent
 	{
 		TGroupBox(std::string Name, __int64 _id) noexcept;
@@ -144,7 +145,7 @@ namespace nk
 		}
 		virtual void draw(struct nk_context* ctx) override;
 	};
-	
+
 	struct TCombobox : public IComponent
 	{
 		TCombobox(std::string Name, __int64 _id) noexcept;
@@ -169,7 +170,7 @@ namespace nk
 		}
 		virtual void draw(struct nk_context* ctx) override;
 	};
-	
+
 	struct TStatusBar : public IComponent
 	{
 		const float& window_height;
@@ -204,11 +205,11 @@ namespace nk
 		}
 		int rowCount() const
 		{
-			return static_cast<int>( Rows.size() );
+			return static_cast<int>(Rows.size());
 		}
 		int colCount() const
 		{
-			return static_cast<int>( Columns.size() );
+			return static_cast<int>(Columns.size());
 		}
 
 		virtual EMyFrameworkType ComponentType() const override {
@@ -217,25 +218,17 @@ namespace nk
 		virtual void draw(struct nk_context* ctx) override;
 	};
 
-
-	
-
-	
 	struct NKForm : public IComponent
 	{
 		const float& Width;
 		const float& Height;
 
-		NKForm( const float& width, const float& height, //width=d3d11.ViewPort.Width ->kind of global, should adapt on Resize!
+		NKForm(const float& width, const float& height, //width=d3d11.ViewPort.Width ->kind of global, should adapt on Resize!
 			std::string Name, __int64 _id) noexcept;
 
 		std::string title;
 		virtual EMyFrameworkType ComponentType() const override;
 		virtual void draw(struct nk_context * ctx) override;
-		
-		
 	};
-
-	
 }
 #endif

--- a/Src/Visual Studio/Nuk/AuswertungNuk/nuk_header_only/nuk_controls.h
+++ b/Src/Visual Studio/Nuk/AuswertungNuk/nuk_header_only/nuk_controls.h
@@ -52,6 +52,7 @@ namespace nk
 	struct TEdit : public IComponent
 	{
 		TEdit(std::string Name, __int64 _id);
+		
 		std::string text;
 		int cursorpos = 0;
 		virtual EMyFrameworkType ComponentType() const override{
@@ -186,6 +187,20 @@ namespace nk
 		virtual void draw(struct nk_context* ctx) override;
 	};
 
+	struct Pool
+	{
+		std::vector< std::unique_ptr<IComponent> > _owned;
+		template<typename outtype, class... Args>
+		outtype* Add(Args&&... ctor_args)
+		{
+			std::unique_ptr<outtype> comp = std::make_unique<outtype>(std::forward<Args>(ctor_args)...);
+			outtype* result = comp.get();
+			_owned.emplace_back(std::move(comp));
+			return result;
+		}
+	};
+
+	
 	struct NKForm : public IComponent
 	{
 		const float& Width;
@@ -197,6 +212,17 @@ namespace nk
 		std::string title;
 		virtual EMyFrameworkType ComponentType() const override;
 		virtual void draw(struct nk_context * ctx) override;
+		
+		static Pool componentPool;
+		template<typename outtype, class... vaList_t>
+		outtype* Create(vaList_t&&... i_values)
+		{
+			outtype* comp= componentPool.Add<outtype>(std::forward<vaList_t>(i_values)...);
+			this->fields.push_back(comp);
+			return comp;
+		}
 	};
+
+	
 }
 #endif

--- a/Src/Visual Studio/Nuk/AuswertungNuk/nuk_header_only/nuk_controls.h
+++ b/Src/Visual Studio/Nuk/AuswertungNuk/nuk_header_only/nuk_controls.h
@@ -32,7 +32,7 @@ namespace nk
 	{
 	public:
 		std::string name;
-		__int64 id=0; //<- while name is empty we need a unique id
+		__int64 id=0; //<- if name is empty we need a unique id
 		IComponent() = delete;
 		IComponent(const IComponent&) = delete;
 		
@@ -63,7 +63,7 @@ namespace nk
 	
 	struct TLabel : public IComponent
 	{
-		TLabel(std::string Name, __int64 _id);
+		TLabel(std::string Name, std::string Text, __int64 _id);
 		std::string text;
 		virtual EMyFrameworkType ComponentType() const override {
 			return EMyFrameworkType::label;
@@ -195,7 +195,13 @@ namespace nk
 		template<typename outtype, class... Args>
 		outtype* Add(Args&&... ctor_args)
 		{
-			std::unique_ptr<outtype> comp = std::make_unique<outtype>(std::forward<Args>(ctor_args)..., ++id);
+			std::unique_ptr<outtype> comp 
+				= std::make_unique<outtype>
+				(
+					std::forward<Args>(ctor_args)...,
+					++id
+				);
+
 			outtype* result = comp.get();
 			_owned.emplace_back(std::move(comp));
 			return result;

--- a/Src/Visual Studio/Nuk/AuswertungNuk/nuk_header_only/nuk_controls.h
+++ b/Src/Visual Studio/Nuk/AuswertungNuk/nuk_header_only/nuk_controls.h
@@ -43,8 +43,8 @@ namespace nk
 		//should draw the component
 		//should redirect "events" -- in case of nuklear onClick is just a bool, discovered while painting
 		//should walk subcomponents, and draw them in specific order
-		virtual void draw(nk_context* ctx) = 0;
-		std::function<void(nk_context*)> applyLayout;
+		virtual void draw(struct nk_context* ctx) = 0;
+		std::function<void(struct nk_context*)> applyLayout;
 		std::vector<IComponent*> fields;
 		IComponent* FindComponent(std::string const& strField);
 	};
@@ -57,7 +57,7 @@ namespace nk
 		virtual EMyFrameworkType ComponentType() const override{
 			return EMyFrameworkType::edit;
 		}
-		virtual void draw(nk_context* ctx) override;
+		virtual void draw(struct nk_context* ctx) override;
 	};
 	
 	struct TLabel : public IComponent
@@ -67,7 +67,7 @@ namespace nk
 		virtual EMyFrameworkType ComponentType() const override {
 			return EMyFrameworkType::label;
 		}
-		virtual void draw(nk_context* ctx) override;
+		virtual void draw(struct nk_context* ctx) override;
 	};
 	
 	struct TGroupBox : public IComponent
@@ -77,7 +77,7 @@ namespace nk
 		virtual EMyFrameworkType ComponentType() const override {
 			return EMyFrameworkType::groupbox;
 		}
-		virtual void draw(nk_context* ctx) override;
+		virtual void draw(struct nk_context* ctx) override;
 	};
 
 	struct TButton : public IComponent
@@ -88,7 +88,7 @@ namespace nk
 		virtual EMyFrameworkType ComponentType() const override {
 			return EMyFrameworkType::button;
 		}
-		virtual void draw(nk_context* ctx) override;
+		virtual void draw(struct nk_context* ctx) override;
 	};
 
 	struct TListbox : public IComponent
@@ -100,7 +100,7 @@ namespace nk
 		virtual EMyFrameworkType ComponentType() const override {
 			return EMyFrameworkType::listbox;
 		}
-		virtual void draw(nk_context* ctx) override;
+		virtual void draw(struct nk_context* ctx) override;
 	};
 
 	struct TCheckbox : public IComponent
@@ -111,7 +111,7 @@ namespace nk
 		virtual EMyFrameworkType ComponentType() const override {
 			return EMyFrameworkType::checkbox;
 		}
-		virtual void draw(nk_context* ctx) override;
+		virtual void draw(struct nk_context* ctx) override;
 	};
 	
 	struct TCombobox : public IComponent
@@ -124,7 +124,7 @@ namespace nk
 		virtual EMyFrameworkType ComponentType() const override {
 			return EMyFrameworkType::combobox;
 		}
-		virtual void draw(nk_context* ctx) override;
+		virtual void draw(struct nk_context* ctx) override;
 	};
 
 	struct TMemo : public IComponent
@@ -136,22 +136,23 @@ namespace nk
 		virtual EMyFrameworkType ComponentType() const override {
 			return EMyFrameworkType::memo;
 		}
-		virtual void draw(nk_context* ctx) override;
+		virtual void draw(struct nk_context* ctx) override;
 	};
 	
 	struct TStatusBar : public IComponent
 	{
-		TStatusBar(int& h, int& w, std::string Name, __int64 _id);
+		const float& window_height;
+		const float& window_width;
+
+		TStatusBar(const float& w, const float& h, std::string Name, __int64 _id);
 
 		std::string text;
-		int& window_height;
-		int& window_width;
-		int status_height;
+		float status_height;
 
 		virtual EMyFrameworkType ComponentType() const override {
 			return EMyFrameworkType::statusbar;
 		}
-		virtual void draw(nk_context* ctx) override;
+		virtual void draw(struct nk_context* ctx) override;
 	};
 
 	struct TGrid : public IComponent
@@ -182,19 +183,20 @@ namespace nk
 		virtual EMyFrameworkType ComponentType() const override {
 			return EMyFrameworkType::listview;
 		}
-		virtual void draw(nk_context* ctx) override;
+		virtual void draw(struct nk_context* ctx) override;
 	};
 
 	struct NKForm : public IComponent
 	{
+		const float& Width;
+		const float& Height;
+
 		NKForm( const float& width, const float& height, //width=d3d11.ViewPort.Width ->kind of global, should adapt on Resize!
 			std::string Name, __int64 _id);
 
 		std::string title;
-		const float& Width;
-		const float& Height;
 		virtual EMyFrameworkType ComponentType() const override;
-		virtual void draw(nk_context * ctx) override;
+		virtual void draw(struct nk_context * ctx) override;
 	};
 }
 #endif

--- a/Src/Visual Studio/Nuk/AuswertungNuk/nuk_header_only/nuk_d3dapp.cpp
+++ b/Src/Visual Studio/Nuk/AuswertungNuk/nuk_header_only/nuk_d3dapp.cpp
@@ -185,14 +185,18 @@ void Application::Run( nk::NKForm& mainForm )
 		//nk_end(ctx);
 
 		//TStatusBar
-		if (nk_begin(ctx, "StatusBar", nk_rect(0, d3d11.viewport.Height - 30, d3d11.viewport.Width, 30),
+		/*if (nk_begin(ctx, "StatusBar", nk_rect(0, d3d11.viewport.Height - 30, d3d11.viewport.Width, 30),
 			NK_WINDOW_BORDER | NK_WINDOW_NO_SCROLLBAR
 		))
 		{
 			nk_layout_row_dynamic(ctx, ctx->current->bounds.h, 1);
 			nk_label(ctx, "statustext", NK_TEXT_CENTERED);
 		}
-		nk_end(ctx);
+		nk_end(ctx);*/
+
+		
+
+
 
 
 		/* Draw */

--- a/Src/Visual Studio/Nuk/AuswertungNuk/nuk_header_only/nuk_d3dapp.cpp
+++ b/Src/Visual Studio/Nuk/AuswertungNuk/nuk_header_only/nuk_d3dapp.cpp
@@ -145,42 +145,44 @@ void Application::Run( nk::NKForm& mainForm )
 		}
 		nk_input_end(ctx);
 
-		/* GUI */
-		if (nk_begin(ctx, "Demo", nk_rect(0, 0, d3d11.viewport.Width*0.8f, d3d11.viewport.Height*0.8f),
-			NK_WINDOW_BORDER | NK_WINDOW_TITLE
-			//| NK_WINDOW_SCALABLE | NK_WINDOW_MOVABLE //<- updates bounds.. fullscreenwindow
-			| NK_WINDOW_MINIMIZABLE
-		))
-		{
+		mainForm.draw(ctx);
+		
+		///* GUI */
+		//if (nk_begin(ctx, "Demo", nk_rect(0, 0, d3d11.viewport.Width*0.8f, d3d11.viewport.Height*0.8f),
+		//	NK_WINDOW_BORDER | NK_WINDOW_TITLE
+		//	//| NK_WINDOW_SCALABLE | NK_WINDOW_MOVABLE //<- updates bounds.. fullscreenwindow
+		//	| NK_WINDOW_MINIMIZABLE
+		//))
+		//{
 
-			enum { EASY, HARD };
-			static int op = EASY;
-			static int property = 20;
+		//	enum { EASY, HARD };
+		//	static int op = EASY;
+		//	static int property = 20;
 
-			nk_layout_row_static(ctx, 30, 80, 1);
-			if (nk_button_label(ctx, "button"))
-				fprintf(stdout, "button pressed\n");
-			nk_layout_row_dynamic(ctx, 30, 2);
-			if (nk_option_label(ctx, "easy", op == EASY)) op = EASY;
-			if (nk_option_label(ctx, "hard", op == HARD)) op = HARD;
-			nk_layout_row_dynamic(ctx, 22, 1);
-			nk_property_int(ctx, "Compression:", 0, &property, 100, 10, 1);
+		//	nk_layout_row_static(ctx, 30, 80, 1);
+		//	if (nk_button_label(ctx, "button"))
+		//		fprintf(stdout, "button pressed\n");
+		//	nk_layout_row_dynamic(ctx, 30, 2);
+		//	if (nk_option_label(ctx, "easy", op == EASY)) op = EASY;
+		//	if (nk_option_label(ctx, "hard", op == HARD)) op = HARD;
+		//	nk_layout_row_dynamic(ctx, 22, 1);
+		//	nk_property_int(ctx, "Compression:", 0, &property, 100, 10, 1);
 
-			nk_layout_row_dynamic(ctx, 20, 1);
-			nk_label(ctx, "background:", NK_TEXT_LEFT);
-			nk_layout_row_dynamic(ctx, 25, 1);
-			if (nk_combo_begin_color(ctx, nk_rgb_cf(bg), nk_vec2(nk_widget_width(ctx), 400))) {
-				nk_layout_row_dynamic(ctx, 120, 1);
-				bg = nk_color_picker(ctx, bg, NK_RGBA);
-				nk_layout_row_dynamic(ctx, 25, 1);
-				bg.r = nk_propertyf(ctx, "#R:", 0, bg.r, 1.0f, 0.01f, 0.005f);
-				bg.g = nk_propertyf(ctx, "#G:", 0, bg.g, 1.0f, 0.01f, 0.005f);
-				bg.b = nk_propertyf(ctx, "#B:", 0, bg.b, 1.0f, 0.01f, 0.005f);
-				bg.a = nk_propertyf(ctx, "#A:", 0, bg.a, 1.0f, 0.01f, 0.005f);
-				nk_combo_end(ctx);
-			}
-		}
-		nk_end(ctx);
+		//	nk_layout_row_dynamic(ctx, 20, 1);
+		//	nk_label(ctx, "background:", NK_TEXT_LEFT);
+		//	nk_layout_row_dynamic(ctx, 25, 1);
+		//	if (nk_combo_begin_color(ctx, nk_rgb_cf(bg), nk_vec2(nk_widget_width(ctx), 400))) {
+		//		nk_layout_row_dynamic(ctx, 120, 1);
+		//		bg = nk_color_picker(ctx, bg, NK_RGBA);
+		//		nk_layout_row_dynamic(ctx, 25, 1);
+		//		bg.r = nk_propertyf(ctx, "#R:", 0, bg.r, 1.0f, 0.01f, 0.005f);
+		//		bg.g = nk_propertyf(ctx, "#G:", 0, bg.g, 1.0f, 0.01f, 0.005f);
+		//		bg.b = nk_propertyf(ctx, "#B:", 0, bg.b, 1.0f, 0.01f, 0.005f);
+		//		bg.a = nk_propertyf(ctx, "#A:", 0, bg.a, 1.0f, 0.01f, 0.005f);
+		//		nk_combo_end(ctx);
+		//	}
+		//}
+		//nk_end(ctx);
 
 		//TStatusBar
 		if (nk_begin(ctx, "StatusBar", nk_rect(0, d3d11.viewport.Height - 30, d3d11.viewport.Width, 30),


### PR DESCRIPTION
moved the static drawing-code into the actual classes
added global componentpool for memory-management
AddField-Method to add Component to a parent-control
drawing of basic control-types: TEdit,TLabel,TStatusBar,NKForm
testbench for drawing a lot of edits and labels in a grid
short test, is TProcess.Init fails, as required Controls and Controlnames are not present yet.